### PR TITLE
feat: Untangle some logic

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -24,9 +24,16 @@ FAIRPOST_OAUTH_PORT=8000
 # rest api server settings
 FAIRPOST_SERVER_BIND=localhost
 FAIRPOST_SERVER_PORT=8000
-FAIRPOST_SERVER_CORS=*
+# live access
+#FAIRPOST_SERVER_CORS=http://foobar.ui
+#FAIRPOST_SESSION_SECURE=false
+#FAIRPOST_SESSION_SAMESITE=strict # strict|lax|none
+#FAIRPOST_SESSION_TIMEOUT=3600
+ls
+# dev access
+FAIRPOST_SERVER_CORS=https://localhost:5173
 FAIRPOST_SESSION_SECURE=true
-FAIRPOST_SESSION_SAMESITE=strict # strict|lax|none
+FAIRPOST_SESSION_SAMESITE=none # strict|lax|none
 FAIRPOST_SESSION_TIMEOUT=3600
 
 # user feed settings (defaults)

--- a/docs/Fairpost.md
+++ b/docs/Fairpost.md
@@ -37,11 +37,14 @@ const post = source.getPost(platform);
 
 ## Post Status and Source Stage
 
+A Post has a `status` in the publishing flow,
+like 'scheduled' or 'canceled'.
+
 The stage of a source depends on the statuses of 
 all posts in the source. The first stage is 
 `incoming`, the final stage is `archived`. 
 The path to the source folder, containing all
-the posts, is defined by the soure stage.
+the posts, is defined by the source stage.
 
 ## DTOs
 

--- a/docs/NewPlatform.md
+++ b/docs/NewPlatform.md
@@ -12,7 +12,9 @@ that works depends on the platform; ymmv.
 
 To add support for a new platform, add a class to `src/platforms`
 extending `src/classes/Platform`. You want to override at least the
-method `preparePost(source)` and  `publishPost(post,dryrun)`.
+method `publishPost(post,dryrun)` and the `pluginSettings`
+to configure things like maximum image or text size. For more
+detail, you can override the `preparePost(post)` method, too.
 
 Make sure not to throw errors in or below publishPost; instead, just 
 return false and let the `Post.processResult()` itself.
@@ -28,7 +30,13 @@ export default class FooBar extends Platform {
 
     assetsFolder = "_foobar";
     postFileName = "post.json";
-    
+    pluginSettings = {
+      limitfiles: {
+        prefer: ["video"],
+        total_max: 1,
+      },
+    };
+
     constructor(user: User) {
       super(user);
     }

--- a/docs/NewPlatform.md
+++ b/docs/NewPlatform.md
@@ -152,14 +152,12 @@ for you to throw:
     throw this.user.log.error('foo', 'bar', 'quz');
 ```
 
-### Using Plugins to prepare your Post
+### Using Plugins after preparing your Post
 
-Inside `preparePost`, you can call plugins to, for example,
-limit the files to a certain type or scale down images, etcetera.
+When a Post is prepared, after `Platform.preparePost`
+has finished, the post calls `this.platform.loadPlugins()`
+to run plugins configured for this platform. 
 See [Plugins](Plugins.md) for a more detailed description.
-If you want users to be able to finetune the plugin settings,
-or even enable additional plugins, read the plugin ids and/or
-settings using `User.get(...)`.
 
 ### Add input/output for custom settings in your platform
 

--- a/docs/NewPlatform.md
+++ b/docs/NewPlatform.md
@@ -34,13 +34,13 @@ export default class FooBar extends Platform {
     }
     
     /** @inheritdoc */
-    async preparePost(source: Source): Promise<Post> {
-        const post = await this.getPost(source);
-        await post.prepare();
+    async preparePost(post: Post) {
         // prepare your platform specific stuff here
         // that includes plugins ...
-        await post.save();
-        return post;
+        // for example
+        if (post.hasFiles(FileGroup.VIDEO)) {
+          post.removeFiles(FileGroup.IMAGE);
+        }
     }
 
     /** @inheritdoc */

--- a/docs/NewPlatform.md
+++ b/docs/NewPlatform.md
@@ -35,11 +35,11 @@ export default class FooBar extends Platform {
     
     /** @inheritdoc */
     async preparePost(source: Source): Promise<Post> {
-        const post = await super.preparePost(source);
-        if (post) {
-            // prepare your post here
-            await post.save();
-        }
+        const post = await this.getPost(source);
+        await post.prepare();
+        // prepare your platform specific stuff here
+        // that includes plugins ...
+        await post.save();
         return post;
     }
 

--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -11,12 +11,35 @@ defaults/settings differs per plugin.
 
 It's the platform source that defines the required
 plugins and its default settings; some platform may 
-allow a user to add more plugins and/or change the 
+allow a user to add more plugins and/or override the 
 settings.
 
 ## Calling a plugin
 
-To have a plugin process a post, simply create the
+Inside a `Platform`, `pluginSettings` is an object
+with plugin ids as keys and default settings as values.
+One optional key, 'name', is reserved for the name of these
+settings in User.settings, that can override these
+defaults.
+
+```php
+<?php
+
+export default class MyPlatform extends Platform {
+  pluginSettings = {
+    name: 'MYPLATFORM_PLUGIN_SETTINGS',
+    textsize: {
+      max_length: 300,
+    },
+  }
+```
+
+Using this, on preparePost, the textSite plugin
+will be applied automatically with the settings given,
+and these settings can be overriden with MYPLATFORM_PLUGIN_SETTINGS
+in the user settings.
+
+To call a plugin manually instead, instantiate the
 plugin with optionally its settings, and call the 
 `process` method. The example below will scale all
 images in your post to have a maximum of 300px width,
@@ -36,22 +59,6 @@ await imgsize.process(post);
 post.save();
 ```
 
-Inside a `Platform`, can load multiple plugins at once,
-passing the settings for all of them keyed by their id.
-The below code does the same as the above code:
-
-```php
-<?php
-
-const plugins = this.loadPlugins({
-    'limitfiles': { max_images: 3 },
-    'imagesize': { max_width: 300 }
-});
-for (const plugin of plugins) {
-    await plugin.process(post);
-}
-post.save();
-```
 
 ## Writing a plugin
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fairpost",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "type": "module",
   "engines": {
     "node": "22.17.0"

--- a/src/models/Feed.ts
+++ b/src/models/Feed.ts
@@ -132,7 +132,8 @@ export default class Feed {
         });
 
         for await (const file of files) {
-          const source = await Source.getSource(this, basename(file.path));
+          const sourceId = Source.getSourceId(file.path);
+          const source = await this.getSource(sourceId);
           this.cache[source.id] = source;
           sources.push(source);
         }
@@ -162,8 +163,15 @@ export default class Feed {
     if (id in this.cache) {
       return this.cache[id];
     }
-    const source = await Source.getSource(this, id, stage);
-    this.cache[source.id] = source;
-    return source;
+    const stages = stage ? [stage] : Object.values(SourceStage);
+    for (const stage of stages) {
+      const sourcePath = Source.getSourcePath(this, id, stage);
+      if (await this.user.files.isDir(sourcePath)) {
+        const source = new Source(this, sourcePath);
+        this.cache[source.id] = source;
+        return source;
+      }
+    }
+    throw this.user.log.error("getSource", "Source not found: " + id, stage);
   }
 }

--- a/src/models/Feed.ts
+++ b/src/models/Feed.ts
@@ -7,7 +7,7 @@ import { basename } from "path";
 /**
  * Feed - the sources handler of fairpost
  *
- * The feed is a container of sources. The sources
+ * The feed is the owner of sources. The sources
  * path is set by USER_FEEDPATH. Every dir in there,
  * if not starting with _ or ., is a source.
  *
@@ -79,6 +79,27 @@ export default class Feed {
   }
 
   /**
+   * getSourcePath
+   *
+   * Get the path for a source in this feed, based on stage and id
+   * @param id - the id of the source
+   * @param stage - the stage of the source
+   * @returns the path to the source
+   */
+  public getSourcePath(id: string, stage: SourceStage): string {
+    return this.getStagePath(stage) + "/" + id;
+  }
+
+  /**
+   * get source id based on the path of a source
+   * @param path the path for the new or existing source
+   * @returns the id for the new or existing source
+   */
+  public getSourceId(path: string): string {
+    return basename(path); // ah, simple
+  }
+
+  /**
    * Get multiple sources
    * @param sourceIds optional array of ids of source you want to get
    * @param stage optional stage of the sources you want to get
@@ -132,7 +153,7 @@ export default class Feed {
         });
 
         for await (const file of files) {
-          const sourceId = Source.getSourceId(file.path);
+          const sourceId = this.getSourceId(file.path);
           const source = await this.getSource(sourceId);
           this.cache[source.id] = source;
           sources.push(source);
@@ -152,6 +173,7 @@ export default class Feed {
       return sources;
     }
   }
+
   /**
    * Get one source, and use a local cache.
    * @param id - id of the source
@@ -165,7 +187,7 @@ export default class Feed {
     }
     const stages = stage ? [stage] : Object.values(SourceStage);
     for (const stage of stages) {
-      const sourcePath = Source.getSourcePath(this, id, stage);
+      const sourcePath = this.getSourcePath(id, stage);
       if (await this.user.files.isDir(sourcePath)) {
         const source = new Source(this, sourcePath);
         this.cache[source.id] = source;

--- a/src/models/Platform.ts
+++ b/src/models/Platform.ts
@@ -26,6 +26,10 @@ export default class Platform {
   postFileName: string = "post.json";
   mapper!: PlatformMapper; // child *must* set this
   settings: FieldMapping = {};
+  pluginSettings: {
+    name?: string;
+    [pluginid: string]: object | string | undefined;
+  } = {};
   interval: number;
   constructor(user: User) {
     this.user = user;
@@ -485,14 +489,32 @@ export default class Platform {
   }
 
   /**
-   * @returns array of instances of the plugins given with the settings given.
+   * @returns array of instances of the plugins
+   *
+   * - will load plugins given in Platform.pluginSettings
+   * - with the settings given in that object
+   * - but if Platform.pluginSettings.name is set,
+   *   also load that value from user settings and
+   *   override the default platform settings
    */
-  loadPlugins(pluginSettings: { [pluginid: string]: object }): Plugin[] {
+  loadPlugins(): Plugin[] {
     const plugins: Plugin[] = [];
+    let pluginSettings = this.pluginSettings;
+    if (this.pluginSettings.name) {
+      const userPluginSettings = JSON.parse(
+        this.user.data.get("settings", this.pluginSettings.name, "{}"),
+      );
+      pluginSettings = {
+        ...this.pluginSettings,
+        ...(userPluginSettings || {}),
+      };
+    }
     Object.values(pluginClasses).forEach((pluginClass) => {
       const pluginId = pluginClass.id();
       if (pluginId in pluginSettings) {
-        plugins?.push(new pluginClass(pluginSettings[pluginId]));
+        if (typeof pluginSettings[pluginId] === "object") {
+          plugins?.push(new pluginClass(pluginSettings[pluginId]));
+        }
       }
     });
     return plugins;

--- a/src/models/Platform.ts
+++ b/src/models/Platform.ts
@@ -498,7 +498,7 @@ export default class Platform {
     this.user.log.trace("Platform", this.id, "publishDuePost", dryrun);
     const post = await this.getDuePost(sources);
     if (post) {
-      await post.publish(dryrun);
+      await this.publishPost(post,dryrun);
       return post;
     }
   }

--- a/src/models/Platform.ts
+++ b/src/models/Platform.ts
@@ -343,8 +343,7 @@ export default class Platform {
    * Prepare a post for this platform for the
    * given source. If it doesn't exist, create it.
    *
-   * Override this in your own platform, but
-   * always call super.preparePost()
+   * Override this in your own platform !
    *
    * If the post exists and is published, ignores it.
    * If the post exists and is failed, sets it back to
@@ -357,27 +356,16 @@ export default class Platform {
    * before, and manually adapted later. For example,
    * post.status may have manually been set to canceled.
    * @param source - the source for which to prepare a post for this platform
-   * @param save - wether to save the post already
    * @returns the prepared post
    */
-  async preparePost(source: Source, save?: true): Promise<Post> {
+  async preparePost(source: Source): Promise<Post> {
     this.user.log.trace("Platform", this.id, "preparePost");
-    const post = await this.getPost(source);
-    if (post.status === PostStatus.PUBLISHED) {
-      return post;
-    }
-    await post.prepare();
-    if (post.status === PostStatus.UNKNOWN) {
-      post.status = PostStatus.UNSCHEDULED;
-    }
-    if (post.status === PostStatus.FAILED) {
-      post.status = PostStatus.UNSCHEDULED;
-    }
-    if (save) {
-      await post.save();
-    }
-
-    return post;
+    throw this.user.log.error(
+      "Prepare not implemented for " +
+        this.id +
+        ". Read the docs in the docs folder.",
+      source.id,
+    );
   }
 
   /**

--- a/src/models/Platform.ts
+++ b/src/models/Platform.ts
@@ -498,7 +498,7 @@ export default class Platform {
     this.user.log.trace("Platform", this.id, "publishDuePost", dryrun);
     const post = await this.getDuePost(sources);
     if (post) {
-      await this.publishPost(post,dryrun);
+      await this.publishPost(post, dryrun);
       return post;
     }
   }

--- a/src/models/Platform.ts
+++ b/src/models/Platform.ts
@@ -6,7 +6,7 @@ import { FieldMapping, SourceStage, PostStatus } from "../types/index.ts";
 import Source from "./Source.ts";
 import Operator from "./Operator.ts";
 import Plugin from "./Plugin.ts";
-import Post from "./Post.ts";
+import Post, { PostFactory } from "./Post.ts";
 import User from "./User.ts";
 
 /**
@@ -201,7 +201,7 @@ export default class Platform {
     const postId = this.getPostId(source);
     if (!(postId in this.cache)) {
       this.user.log.trace("Platform", this.id, "getPost", source.id);
-      const post = await Post.getPost(this, source);
+      const post = await PostFactory.resolve(this, source);
       this.cache[postId] = post;
     }
     return this.cache[postId];

--- a/src/models/Platform.ts
+++ b/src/models/Platform.ts
@@ -355,14 +355,10 @@ export default class Platform {
    * post.status may have manually been set to canceled.
    * @param post - the post to prepare
    */
+
   async preparePost(post: Post) {
-    this.user.log.trace("Platform", this.id, "preparePost");
-    throw this.user.log.error(
-      "Prepare not implemented for " +
-        this.id +
-        ". Read the docs in the docs folder.",
-      post.id,
-    );
+    this.user.log.trace("Platform.preparePost: noop", post.id);
+    // noop
   }
 
   /**

--- a/src/models/Platform.ts
+++ b/src/models/Platform.ts
@@ -479,7 +479,7 @@ export default class Platform {
     this.user.log.trace("Platform", this.id, "publishDuePost", dryrun);
     const post = await this.getDuePost(sources);
     if (post) {
-      await this.publishPost(post, dryrun);
+      await post.publish(dryrun);
       return post;
     }
   }

--- a/src/models/Platform.ts
+++ b/src/models/Platform.ts
@@ -340,14 +340,8 @@ export default class Platform {
   /**
    * preparePost
    *
-   * Prepare a post for this platform for the
-   * given source. If it doesn't exist, create it.
-   *
+   * Prepare the post for this platform.
    * Override this in your own platform !
-   *
-   * If the post exists and is published, ignores it.
-   * If the post exists and is failed, sets it back to
-   * unscheduled.
    *
    * Do not throw errors. Instead, catch and log them,
    * and set the post.valid to false
@@ -355,16 +349,15 @@ export default class Platform {
    * Presume the post may have already been prepared
    * before, and manually adapted later. For example,
    * post.status may have manually been set to canceled.
-   * @param source - the source for which to prepare a post for this platform
-   * @returns the prepared post
+   * @param post - the post to prepare
    */
-  async preparePost(source: Source): Promise<Post> {
+  async preparePost(post: Post) {
     this.user.log.trace("Platform", this.id, "preparePost");
     throw this.user.log.error(
       "Prepare not implemented for " +
         this.id +
         ". Read the docs in the docs folder.",
-      source.id,
+      post.id,
     );
   }
 

--- a/src/models/Post.ts
+++ b/src/models/Post.ts
@@ -128,15 +128,18 @@ export default class Post {
   /**
    * Prepare this post
    *
-   * Called from Platform.preparePost;
-   *
    * The post may already be prepared before,
    * but then things may have changed.
+   *
+   * If the is published, ignores it.
+   * If the is failed, sets it back to
+   * unscheduled.
    *
    * always updates the files, they may have changed
    * on disk; but also maintains some properties that may have
    * been changed manually
    *
+   * Finally, Calls platform.preparePost()
    * Does not save the post.
    */
 
@@ -224,7 +227,8 @@ export default class Post {
       this.status = PostStatus.UNSCHEDULED;
     }
 
-    // done
+    await this.platform.preparePost(this);
+    await this.save();
   }
 
   /**

--- a/src/models/Post.ts
+++ b/src/models/Post.ts
@@ -229,6 +229,17 @@ export default class Post {
 
     await this.platform.preparePost(this);
 
+    if (this.valid) {
+      const plugins = this.platform.loadPlugins();
+      for (const plugin of plugins) {
+        try {
+          await plugin.process(this);
+        } catch {
+          this.valid = false;
+        }
+      }
+    }
+
     await this.save();
   }
 

--- a/src/models/Post.ts
+++ b/src/models/Post.ts
@@ -228,6 +228,7 @@ export default class Post {
     }
 
     await this.platform.preparePost(this);
+
     await this.save();
   }
 

--- a/src/models/Post.ts
+++ b/src/models/Post.ts
@@ -1,4 +1,5 @@
 import { FileGroup, FileInfo, PostStatus, PostResult } from "../types/index.ts";
+import User from "./User.ts";
 import Source from "./Source.ts";
 import Platform from "./Platform.ts";
 import { isSimilarArray } from "../utilities.ts";
@@ -7,7 +8,7 @@ import PostMapper from "../mappers/PostMapper.ts";
 /**
  * Post - a post within a source
  *
- * A post belongs to one platform and one source;
+ * A post belongs to both one platform and one source;
  * it is *prepared* and later *published* by the platform.
  * The post serializes to a json file in the source,
  * where it can be read later for further processing.
@@ -21,12 +22,13 @@ import PostMapper from "../mappers/PostMapper.ts";
  */
 export default class Post {
   id: string;
+  user: User;
   source: Source;
   platform: Platform;
   valid: boolean = false;
   status: PostStatus = PostStatus.UNKNOWN;
+  originalStatus: PostStatus = PostStatus.UNKNOWN;
   prepared: boolean = false;
-  private originalStatus: PostStatus = PostStatus.UNKNOWN;
   scheduled?: Date;
   published?: Date;
   results: PostResult[] = [];
@@ -43,11 +45,24 @@ export default class Post {
 
   /**
    * Dont call the constructor yourself;
-   * instead, call `await Post.getPost()`
+   * instead, call `await PostFactory.resolve()`
    * @param platform
    * @param source
    */
   constructor(platform: Platform, source: Source) {
+    if (platform.user !== source.feed.user) {
+      source.feed.user.log.error(
+        "Creating source post from wrong platform",
+        platform.id,
+        source.id,
+      );
+      throw platform.user.log.error(
+        "Creating platform post from wrong source",
+        platform.id,
+        source.id,
+      );
+    }
+    this.user = platform.user;
     this.id = platform.getPostId(source);
     this.platform = platform;
     this.source = source;
@@ -55,45 +70,11 @@ export default class Post {
   }
 
   /**
-   * getPost
-   *
-   * get a new post and load the async data.
-   * @param platform - the platform this post belongs to
-   * @param source - the source this post is derived from
-   * @returns new post object
-   */
-  static async getPost(platform: Platform, source: Source): Promise<Post> {
-    const post = new Post(platform, source);
-    const postFilePath = platform.getPostFilePath(source);
-    if (!(await platform.user.files.exists(postFilePath))) {
-      return post;
-    }
-    const contents = await platform.user.files.readFile(postFilePath);
-    const data = JSON.parse(contents);
-    if (!data) {
-      throw platform.user.log.error(
-        "Cant parse post ",
-        post.id,
-        post.source.id,
-      );
-    }
-    Object.assign(post, data);
-    post.id = platform.getPostId(source);
-    post.prepared = true;
-    post.scheduled = post.scheduled ? new Date(post.scheduled) : undefined;
-    post.published = post.published ? new Date(post.published) : undefined;
-    post.ignoreFiles = post.ignoreFiles ?? [];
-    post.originalStatus = post.status;
-
-    return post;
-  }
-
-  /**
    * Save this post to disk
    */
 
   async save() {
-    this.platform.user.log.trace("Post", "save");
+    this.user.log.trace("Post", "save");
     // eslint-disable-next-line  @typescript-eslint/no-explicit-any
     const data = { ...this } as { [key: string]: any };
     delete data.source;
@@ -101,19 +82,19 @@ export default class Post {
     delete data.mapper;
     delete data.prepared;
     delete data.originalStatus;
-    await this.platform.user.files.write(
+    await this.user.files.write(
       this.platform.getPostFilePath(this.source),
       JSON.stringify(data, null, "\t"),
     );
 
     if (this.originalStatus !== this.status) {
       // update the source status if necessary
-      // note, this may *move* the source and all posts
+      // note, this may *move* the source and all posts in it
       const originalSourceStage = this.source.stage;
       const newSourceStage = await this.source.updateStage();
 
       // update the users report
-      const report = await this.platform.user.getReport();
+      const report = await this.user.getReport();
       if (report.platforms[this.platform.id]) {
         if (!report.platforms[this.platform.id]?.count[this.originalStatus]) {
           report.platforms[this.platform.id]!.count[this.originalStatus] = 1;
@@ -135,13 +116,8 @@ export default class Post {
           report.feed.count[newSourceStage]!++;
         }
         // save the report
-        await this.platform.user.putReport(report);
-        this.platform.user.log.trace(
-          "Post",
-          this.id,
-          "save",
-          "updated user report",
-        );
+        await this.user.putReport(report);
+        this.user.log.trace("Post", this.id, "save", "updated user report");
       }
       // all up to date
       this.originalStatus = this.status;
@@ -164,15 +140,15 @@ export default class Post {
    */
 
   async prepare() {
-    this.platform.user.log.trace("Post", "prepare");
+    this.user.log.trace("Post", "prepare");
 
     // purge non-existing files and
     // update existing files
 
     if (!this.prepared) {
       const assetsPath = this.getFilePath(this.platform.assetsFolder);
-      if (!(await this.platform.user.files.exists(assetsPath))) {
-        await this.platform.user.files.mkdir(assetsPath);
+      if (!(await this.user.files.exists(assetsPath))) {
+        await this.user.files.mkdir(assetsPath);
       }
     } else {
       await this.purgeFiles();
@@ -194,44 +170,36 @@ export default class Post {
     const textFiles = this.getFiles(FileGroup.TEXT);
 
     if (this.hasFile("body.txt")) {
-      this.body = await this.platform.user.files.readFile(
-        this.getFilePath("body.txt"),
-      );
+      this.body = await this.user.files.readFile(this.getFilePath("body.txt"));
     } else if (textFiles.length === 1) {
       const bodyFile = textFiles[0].name;
-      this.body = await this.platform.user.files.readFile(
-        this.getFilePath(bodyFile),
-      );
+      this.body = await this.user.files.readFile(this.getFilePath(bodyFile));
     } else {
       this.body = this.platform.defaultBody;
     }
 
     if (this.hasFile("title.txt")) {
-      this.title = await this.platform.user.files.readFile(
+      this.title = await this.user.files.readFile(
         this.getFilePath("title.txt"),
       );
     } else if (this.hasFile("subject.txt")) {
-      this.title = await this.platform.user.files.readFile(
+      this.title = await this.user.files.readFile(
         this.getFilePath("subject.txt"),
       );
     }
 
     if (this.hasFile("tags.txt")) {
       this.tags = (
-        await this.platform.user.files.readFile(this.getFilePath("tags.txt"))
+        await this.user.files.readFile(this.getFilePath("tags.txt"))
       ).split(/\s/);
     }
     if (this.hasFile("mentions.txt")) {
       this.mentions = this.mentions = (
-        await this.platform.user.files.readFile(
-          this.getFilePath("mentions.txt"),
-        )
+        await this.user.files.readFile(this.getFilePath("mentions.txt"))
       ).split(/\s/);
     }
     if (this.hasFile("geo.txt")) {
-      this.geo = await this.platform.user.files.readFile(
-        this.getFilePath("geo.txt"),
-      );
+      this.geo = await this.user.files.readFile(this.getFilePath("geo.txt"));
     }
 
     // decompile the body to see if there are
@@ -257,33 +225,33 @@ export default class Post {
    */
 
   async setStatus(status: PostStatus) {
-    this.platform.user.log.trace("Post", "setStatus", status);
+    this.user.log.trace("Post", "setStatus", status);
     if (!this.prepared) {
-      throw this.platform.user.log.error("Post is not prepared");
+      throw this.user.log.error("Post is not prepared");
     }
     if (!this.valid) {
-      throw this.platform.user.log.error("Post is not valid");
+      throw this.user.log.error("Post is not valid");
     }
 
     if (this.status === status) {
-      throw this.platform.user.log.error("Post already on status " + status);
+      throw this.user.log.error("Post already on status " + status);
     }
-    this.platform.user.log.warn("Changing post status to " + status);
+    this.user.log.warn("Changing post status to " + status);
     switch (status) {
       case PostStatus.UNSCHEDULED:
-        this.platform.user.log.warn("Removing scheduled and published dates");
+        this.user.log.warn("Removing scheduled and published dates");
         delete this.scheduled;
         delete this.published;
         break;
       case PostStatus.SCHEDULED:
-        this.platform.user.log.warn(
+        this.user.log.warn(
           "Resetting scheduled date, removing published date, r",
         );
         this.scheduled = this.scheduled || new Date();
         delete this.published;
         break;
       case PostStatus.PUBLISHED:
-        this.platform.user.log.warn("Resetting scheduled and published dates");
+        this.user.log.warn("Resetting scheduled and published dates");
         this.scheduled = this.scheduled || new Date();
         this.published = this.published || new Date();
         break;
@@ -300,18 +268,18 @@ export default class Post {
    */
 
   async schedule(date: Date) {
-    this.platform.user.log.trace("Post", "schedule", date);
+    this.user.log.trace("Post", "schedule", date);
     if (!this.prepared) {
-      throw this.platform.user.log.error("Post is not prepared");
+      throw this.user.log.error("Post is not prepared");
     }
     if (!this.valid) {
-      throw this.platform.user.log.error("Post is not valid");
+      throw this.user.log.error("Post is not valid");
     }
     if (this.status === PostStatus.CANCELED) {
-      throw this.platform.user.log.error("Post has status canceled");
+      throw this.user.log.error("Post has status canceled");
     }
     if (this.status !== PostStatus.UNSCHEDULED) {
-      this.platform.user.log.warn("Rescheduling post");
+      this.user.log.warn("Rescheduling post");
     }
     this.scheduled = date;
     this.status = PostStatus.SCHEDULED;
@@ -328,22 +296,22 @@ export default class Post {
    * @returns boolean if success
    */
   async publish(dryrun: boolean): Promise<boolean> {
-    this.platform.user.log.trace("Post", "publish");
+    this.user.log.trace("Post", "publish");
     if (!this.prepared) {
-      throw this.platform.user.log.error("Post is not prepared");
+      throw this.user.log.error("Post is not prepared");
     }
     if (!this.valid) {
-      throw this.platform.user.log.error("Post is not valid", this.id);
+      throw this.user.log.error("Post is not valid", this.id);
     }
     if (this.status === PostStatus.CANCELED) {
-      throw this.platform.user.log.error("Post has status canceled", this.id);
+      throw this.user.log.error("Post has status canceled", this.id);
     }
     if (this.published) {
-      throw this.platform.user.log.error("Post was already published", this.id);
+      throw this.user.log.error("Post was already published", this.id);
     }
     // why ?
     // if (!dryrun) post.schedule(now);
-    this.platform.user.log.info("Publishing", this.id);
+    this.user.log.info("Publishing", this.id);
     return await this.platform.publishPost(this, dryrun);
   }
 
@@ -525,11 +493,8 @@ export default class Post {
    */
   async purgeFiles() {
     for (const file of this.getFiles()) {
-      if (
-        file.original &&
-        !(await this.platform.user.files.exists(file.original))
-      ) {
-        this.platform.user.log.info(
+      if (file.original && !(await this.user.files.exists(file.original))) {
+        this.user.log.info(
           "Post",
           "purgeFiles",
           "purging non-existant derivate",
@@ -537,10 +502,8 @@ export default class Post {
         );
         this.removeFile(file.name);
       }
-      if (
-        !(await this.platform.user.files.exists(this.getFilePath(file.name)))
-      ) {
-        this.platform.user.log.info(
+      if (!(await this.user.files.exists(this.getFilePath(file.name)))) {
+        this.user.log.info(
           "Post",
           "purgeFiles",
           "purging non-existent file",
@@ -597,15 +560,11 @@ export default class Post {
       if (!this.files) {
         this.files = [];
       }
-      this.platform.user.log.trace("Post.addFile", newFile);
+      this.user.log.trace("Post.addFile", newFile);
       this.files.push(newFile);
       return newFile;
     } else {
-      this.platform.user.log.warn(
-        "Post.addFile",
-        "Not replacing existing file",
-        name,
-      );
+      this.user.log.warn("Post.addFile", "Not replacing existing file", name);
     }
   }
 
@@ -647,7 +606,7 @@ export default class Post {
     search: string,
     replace: string,
   ): Promise<FileInfo | undefined> {
-    this.platform.user.log.trace("Post.replaceFile", search, replace);
+    this.user.log.trace("Post.replaceFile", search, replace);
     const index = this.files?.findIndex((file) => file.name === search) ?? -1;
     if (index > -1) {
       const oldFile = this.getFile(search);
@@ -658,11 +617,7 @@ export default class Post {
         return this.files[index];
       }
     } else {
-      this.platform.user.log.warn(
-        "Post.replaceFile",
-        "metadata not found",
-        search,
-      );
+      this.user.log.warn("Post.replaceFile", "metadata not found", search);
     }
   }
 
@@ -692,7 +647,7 @@ export default class Post {
     this.results.push(result);
 
     if (result.error) {
-      this.platform.user.log.warn(
+      this.user.log.warn(
         "Post.processResult",
         this.id,
         "failed",
@@ -714,5 +669,33 @@ export default class Post {
 
     await this.save();
     return result.success;
+  }
+}
+
+export class PostFactory {
+  static async resolve(platform: Platform, source: Source): Promise<Post> {
+    const post = new Post(platform, source);
+    const postFilePath = platform.getPostFilePath(source);
+    if (!(await platform.user.files.exists(postFilePath))) {
+      // post doesnt exist yet - tis a new post
+      return post;
+    }
+    const contents = await platform.user.files.readFile(postFilePath);
+    const data = JSON.parse(contents);
+    if (!data) {
+      throw platform.user.log.error(
+        "Cant parse post ",
+        post.id,
+        post.source.id,
+      );
+    }
+    Object.assign(post, data);
+    post.id = platform.getPostId(source);
+    post.prepared = true;
+    post.scheduled = post.scheduled ? new Date(post.scheduled) : undefined;
+    post.published = post.published ? new Date(post.published) : undefined;
+    post.ignoreFiles = post.ignoreFiles ?? [];
+    post.originalStatus = post.status;
+    return post;
   }
 }

--- a/src/models/Post.ts
+++ b/src/models/Post.ts
@@ -131,16 +131,17 @@ export default class Post {
    * The post may already be prepared before,
    * but then things may have changed.
    *
-   * If the is published, ignores it.
-   * If the is failed, sets it back to
+   * If the post is published, ignores it.
+   * If the post is failed, sets it back to
    * unscheduled.
    *
    * always updates the files, they may have changed
    * on disk; but also maintains some properties that may have
    * been changed manually
    *
-   * Finally, Calls platform.preparePost()
-   * Does not save the post.
+   * Calls platform.preparePost()
+   * Calls plugin.process(this) for all plugins
+   * Saves the post
    */
 
   async prepare() {

--- a/src/models/Post.ts
+++ b/src/models/Post.ts
@@ -77,6 +77,7 @@ export default class Post {
     this.user.log.trace("Post", "save");
     // eslint-disable-next-line  @typescript-eslint/no-explicit-any
     const data = { ...this } as { [key: string]: any };
+    delete data.user;
     delete data.source;
     delete data.platform;
     delete data.mapper;
@@ -141,6 +142,10 @@ export default class Post {
 
   async prepare() {
     this.user.log.trace("Post", "prepare");
+
+    if (this.status === PostStatus.PUBLISHED) {
+      return;
+    }
 
     // purge non-existing files and
     // update existing files
@@ -211,6 +216,12 @@ export default class Post {
 
     if (this.title) {
       this.valid = true;
+    }
+    if (this.status === PostStatus.UNKNOWN) {
+      this.status = PostStatus.UNSCHEDULED;
+    }
+    if (this.status === PostStatus.FAILED) {
+      this.status = PostStatus.UNSCHEDULED;
     }
 
     // done

--- a/src/models/Source.ts
+++ b/src/models/Source.ts
@@ -241,22 +241,6 @@ export default class Source {
   }
 
   /**
-   * preparePost
-   * this is just an alias of Platform.preparePost(source)
-   */
-
-  public async preparePost(platform: Platform): Promise<Post> {
-    this.feed.user.log.trace(
-      "Source",
-      this.id,
-      "preparePost",
-      this.id,
-      platform.id,
-    );
-    return await platform.preparePost(this);
-  }
-
-  /**
    * getPost
    * this is just an alias of Platform.getPost(source)
    */

--- a/src/models/Source.ts
+++ b/src/models/Source.ts
@@ -39,7 +39,7 @@ export default class Source {
    */
   constructor(feed: Feed, path: string) {
     this.feed = feed;
-    this.id = this.getSourceId(path);
+    this.id = Source.getSourceId(path);
     this.path = path;
     this.mapper = new SourceMapper(this);
     this.stage = this.getSourceStage();
@@ -67,7 +67,7 @@ export default class Source {
    * @param path the path for the new or existing source
    * @returns the id for the new or existing source
    */
-  public getSourceId(path: string): string {
+  public static getSourceId(path: string): string {
     return basename(path); // ah, simple
   }
 
@@ -88,31 +88,6 @@ export default class Source {
       }
     }
     return SourceStage.UNKNOWN;
-  }
-
-  /**
-   * getSource
-   *
-   * get a new source and do some async checks.
-   * @param feed - the feed this source belongs to
-   * @param id - the id of the source
-   * @param stage - optional stage to find the source in
-   * @returns new source object
-   */
-
-  public static async getSource(
-    feed: Feed,
-    id: string,
-    stage?: SourceStage,
-  ): Promise<Source> {
-    const stages = stage ? [stage] : Object.values(SourceStage);
-    for (const stage of stages) {
-      const sourcePath = Source.getSourcePath(feed, id, stage);
-      if (await feed.user.files.isDir(sourcePath)) {
-        return new Source(feed, sourcePath);
-      }
-    }
-    throw feed.user.log.error("getSource", "No source in stage: " + id, stage);
   }
 
   /**

--- a/src/models/Source.ts
+++ b/src/models/Source.ts
@@ -39,36 +39,10 @@ export default class Source {
    */
   constructor(feed: Feed, path: string) {
     this.feed = feed;
-    this.id = Source.getSourceId(path);
+    this.id = feed.getSourceId(path);
     this.path = path;
     this.mapper = new SourceMapper(this);
     this.stage = this.getSourceStage();
-  }
-
-  /**
-   * getSourcePath
-   *
-   * Get the path for a source in a feed, based on stage and id
-   * @param feed - the feed this source belongs to
-   * @param id - the id of the source
-   * @param stage - the stage of the source
-   * @returns the path to the source
-   */
-  public static getSourcePath(
-    feed: Feed,
-    id: string,
-    stage: SourceStage,
-  ): string {
-    return feed.getStagePath(stage) + "/" + id;
-  }
-
-  /**
-   * get source id based on the path of a source
-   * @param path the path for the new or existing source
-   * @returns the id for the new or existing source
-   */
-  public static getSourceId(path: string): string {
-    return basename(path); // ah, simple
   }
 
   /**
@@ -170,7 +144,7 @@ export default class Source {
       }
     }
 
-    const newPath = Source.getSourcePath(this.feed, newId, newStage);
+    const newPath = this.feed.getSourcePath(newId, newStage);
     if (await this.feed.user.files.exists(newPath)) {
       this.feed.user.log.error(
         this.id,

--- a/src/models/Source.ts
+++ b/src/models/Source.ts
@@ -241,18 +241,12 @@ export default class Source {
   }
 
   /**
-   * getPost
-   * this is just an alias of Platform.getPost(source)
+   * Get a single post from this source
+   * @param platform - platform for the post
    */
 
   public async getPost(platform: Platform): Promise<Post> {
-    this.feed.user.log.trace(
-      "Source",
-      this.id,
-      "getPost",
-      this.id,
-      platform.id,
-    );
+    this.feed.user.log.trace("Source", "getPost", this.id, platform.id);
     return await PostFactory.resolve(platform, this);
   }
 

--- a/src/models/Source.ts
+++ b/src/models/Source.ts
@@ -9,7 +9,7 @@ import {
   FileGroup,
 } from "../types/index.ts";
 import Platform from "./Platform.ts";
-import Post from "./Post.ts";
+import Post, { PostFactory } from "./Post.ts";
 import SourceMapper from "../mappers/SourceMapper.ts";
 
 /**
@@ -269,7 +269,7 @@ export default class Source {
       this.id,
       platform.id,
     );
-    return await platform.getPost(this);
+    return await PostFactory.resolve(platform, this);
   }
 
   /**
@@ -290,7 +290,7 @@ export default class Source {
     }
     for (const platform of platforms) {
       try {
-        const post = await this.getPost(platform);
+        const post = await PostFactory.resolve(platform, this);
         if (!status || status === post.status) {
           posts.push(post);
         }

--- a/src/platforms/Bluesky/Bluesky.ts
+++ b/src/platforms/Bluesky/Bluesky.ts
@@ -17,6 +17,7 @@ export default class Bluesky extends Platform {
   assetsFolder = "_bluesky";
   postFileName = "post.json";
   pluginSettings = {
+    name: "BLUESKY_PLUGIN_SETTINGS",
     textsize: {
       max_length: 300,
     },
@@ -96,14 +97,7 @@ export default class Bluesky extends Platform {
 
   async preparePost(post: Post) {
     this.user.log.trace("Bluesky.preparePost", post.id);
-    const userPluginSettings = JSON.parse(
-      this.user.data.get("settings", "BLUESKY_PLUGIN_SETTINGS", "{}"),
-    );
-    const pluginSettings = {
-      ...this.pluginSettings,
-      ...(userPluginSettings || {}),
-    };
-    const plugins = this.loadPlugins(pluginSettings);
+    const plugins = this.loadPlugins();
     for (const plugin of plugins) {
       try {
         await plugin.process(post);

--- a/src/platforms/Bluesky/Bluesky.ts
+++ b/src/platforms/Bluesky/Bluesky.ts
@@ -97,14 +97,6 @@ export default class Bluesky extends Platform {
 
   async preparePost(post: Post) {
     this.user.log.trace("Bluesky.preparePost", post.id);
-    const plugins = this.loadPlugins();
-    for (const plugin of plugins) {
-      try {
-        await plugin.process(post);
-      } catch {
-        post.valid = false;
-      }
-    }
 
     // Annimated GIF will be sent as a video. Only one animated GIF can be sent per post.
 

--- a/src/platforms/Bluesky/Bluesky.ts
+++ b/src/platforms/Bluesky/Bluesky.ts
@@ -97,34 +97,34 @@ export default class Bluesky extends Platform {
 
   async preparePost(source: Source): Promise<Post> {
     this.user.log.trace("Bluesky.preparePost", source.id);
-    const post = await super.preparePost(source);
-    if (post) {
-      const userPluginSettings = JSON.parse(
-        this.user.data.get("settings", "BLUESKY_PLUGIN_SETTINGS", "{}"),
-      );
-      const pluginSettings = {
-        ...this.pluginSettings,
-        ...(userPluginSettings || {}),
-      };
-      const plugins = this.loadPlugins(pluginSettings);
-      for (const plugin of plugins) {
-        try {
-          await plugin.process(post);
-        } catch {
-          post.valid = false;
-        }
+    const post = await this.getPost(source);
+    await post.prepare();
+    const userPluginSettings = JSON.parse(
+      this.user.data.get("settings", "BLUESKY_PLUGIN_SETTINGS", "{}"),
+    );
+    const pluginSettings = {
+      ...this.pluginSettings,
+      ...(userPluginSettings || {}),
+    };
+    const plugins = this.loadPlugins(pluginSettings);
+    for (const plugin of plugins) {
+      try {
+        await plugin.process(post);
+      } catch {
+        post.valid = false;
       }
-
-      // Annimated GIF will be sent as a video. Only one animated GIF can be sent per post.
-
-      // video
-      // Supported formats: MP4.
-      // Duration max: 4 minutes.
-      // Duration min: 1 second.
-      // Aspect ratio must be between 1:3 and 3:1.
-
-      await post.save();
     }
+
+    // Annimated GIF will be sent as a video. Only one animated GIF can be sent per post.
+
+    // video
+    // Supported formats: MP4.
+    // Duration max: 4 minutes.
+    // Duration min: 1 second.
+    // Aspect ratio must be between 1:3 and 3:1.
+
+    await post.save();
+
     return post;
   }
 

--- a/src/platforms/Bluesky/Bluesky.ts
+++ b/src/platforms/Bluesky/Bluesky.ts
@@ -1,5 +1,4 @@
 import { FileGroup, FieldMapping } from "../../types/index.ts";
-import Source from "../../models/Source.ts";
 
 import Operator from "../../models/Operator.ts";
 import Platform from "../../models/Platform.ts";
@@ -95,10 +94,8 @@ export default class Bluesky extends Platform {
 
   /** @inheritdoc */
 
-  async preparePost(source: Source): Promise<Post> {
-    this.user.log.trace("Bluesky.preparePost", source.id);
-    const post = await this.getPost(source);
-    await post.prepare();
+  async preparePost(post: Post) {
+    this.user.log.trace("Bluesky.preparePost", post.id);
     const userPluginSettings = JSON.parse(
       this.user.data.get("settings", "BLUESKY_PLUGIN_SETTINGS", "{}"),
     );
@@ -122,10 +119,6 @@ export default class Bluesky extends Platform {
     // Duration max: 4 minutes.
     // Duration min: 1 second.
     // Aspect ratio must be between 1:3 and 3:1.
-
-    await post.save();
-
-    return post;
   }
 
   /** @inheritdoc */

--- a/src/platforms/Facebook/Facebook.ts
+++ b/src/platforms/Facebook/Facebook.ts
@@ -1,8 +1,6 @@
 import { basename } from "path";
 import { FileGroup, FieldMapping, OAuthRequest } from "../../types/index.ts";
 
-import Source from "../../models/Source.ts";
-
 import FacebookApi from "./FacebookApi.ts";
 import FacebookAuth from "./FacebookAuth.ts";
 import PlatformMapper from "../../mappers/PlatformMapper.ts";
@@ -102,10 +100,8 @@ export default class Facebook extends Platform {
   }
 
   /** @inheritdoc */
-  async preparePost(source: Source): Promise<Post> {
-    this.user.log.trace("Facebook.preparePost", source.id);
-    const post = await this.getPost(source);
-    await post.prepare();
+  async preparePost(post: Post) {
+    this.user.log.trace("Facebook.preparePost", post.id);
     const userPluginSettings = JSON.parse(
       this.user.data.get("settings", "FACEBOOK_PLUGIN_SETTINGS", "{}"),
     );
@@ -117,9 +113,6 @@ export default class Facebook extends Platform {
     for (const plugin of plugins) {
       await plugin.process(post);
     }
-    await post.save();
-
-    return post;
   }
 
   /** @inheritdoc */

--- a/src/platforms/Facebook/Facebook.ts
+++ b/src/platforms/Facebook/Facebook.ts
@@ -103,10 +103,7 @@ export default class Facebook extends Platform {
   /** @inheritdoc */
   async preparePost(post: Post) {
     this.user.log.trace("Facebook.preparePost", post.id);
-    const plugins = this.loadPlugins();
-    for (const plugin of plugins) {
-      await plugin.process(post);
-    }
+    // all good
   }
 
   /** @inheritdoc */

--- a/src/platforms/Facebook/Facebook.ts
+++ b/src/platforms/Facebook/Facebook.ts
@@ -104,21 +104,21 @@ export default class Facebook extends Platform {
   /** @inheritdoc */
   async preparePost(source: Source): Promise<Post> {
     this.user.log.trace("Facebook.preparePost", source.id);
-    const post = await super.preparePost(source);
-    if (post && post.files) {
-      const userPluginSettings = JSON.parse(
-        this.user.data.get("settings", "FACEBOOK_PLUGIN_SETTINGS", "{}"),
-      );
-      const pluginSettings = {
-        ...this.pluginSettings,
-        ...(userPluginSettings || {}),
-      };
-      const plugins = this.loadPlugins(pluginSettings);
-      for (const plugin of plugins) {
-        await plugin.process(post);
-      }
-      await post.save();
+    const post = await this.getPost(source);
+    await post.prepare();
+    const userPluginSettings = JSON.parse(
+      this.user.data.get("settings", "FACEBOOK_PLUGIN_SETTINGS", "{}"),
+    );
+    const pluginSettings = {
+      ...this.pluginSettings,
+      ...(userPluginSettings || {}),
+    };
+    const plugins = this.loadPlugins(pluginSettings);
+    for (const plugin of plugins) {
+      await plugin.process(post);
     }
+    await post.save();
+
     return post;
   }
 

--- a/src/platforms/Facebook/Facebook.ts
+++ b/src/platforms/Facebook/Facebook.ts
@@ -21,6 +21,7 @@ export default class Facebook extends Platform {
   assetsFolder = "_facebook";
   postFileName = "post.json";
   pluginSettings = {
+    name: "FACEBOOK_PLUGIN_SETTINGS",
     limitfiles: {
       exclusive: ["video"],
       video_max: 1,
@@ -102,14 +103,7 @@ export default class Facebook extends Platform {
   /** @inheritdoc */
   async preparePost(post: Post) {
     this.user.log.trace("Facebook.preparePost", post.id);
-    const userPluginSettings = JSON.parse(
-      this.user.data.get("settings", "FACEBOOK_PLUGIN_SETTINGS", "{}"),
-    );
-    const pluginSettings = {
-      ...this.pluginSettings,
-      ...(userPluginSettings || {}),
-    };
-    const plugins = this.loadPlugins(pluginSettings);
+    const plugins = this.loadPlugins();
     for (const plugin of plugins) {
       await plugin.process(post);
     }

--- a/src/platforms/Instagram/Instagram.ts
+++ b/src/platforms/Instagram/Instagram.ts
@@ -103,32 +103,32 @@ export default class Instagram extends Platform {
   /** @inheritdoc */
   async preparePost(source: Source): Promise<Post> {
     this.user.log.trace("Instagram.preparePost", source.id);
-    const post = await super.preparePost(source);
-    if (post && post.files) {
-      // instagram: require media
-      if (
-        post.getFiles(FileGroup.IMAGE).length +
-          post.getFiles(FileGroup.VIDEO).length ===
-        0
-      ) {
-        post.valid = false;
-      }
-      if (post.valid) {
-        const userPluginSettings = JSON.parse(
-          this.user.data.get("settings", "INSTAGRAM_PLUGIN_SETTINGS", "{}"),
-        );
-        const pluginSettings = {
-          ...this.pluginSettings,
-          ...(userPluginSettings || {}),
-        };
-        const plugins = this.loadPlugins(pluginSettings);
-        for (const plugin of plugins) {
-          await plugin.process(post);
-        }
-      }
-
-      await post.save();
+    const post = await this.getPost(source);
+    await post.prepare();
+    // instagram: require media
+    if (
+      post.getFiles(FileGroup.IMAGE).length +
+        post.getFiles(FileGroup.VIDEO).length ===
+      0
+    ) {
+      post.valid = false;
     }
+    if (post.valid) {
+      const userPluginSettings = JSON.parse(
+        this.user.data.get("settings", "INSTAGRAM_PLUGIN_SETTINGS", "{}"),
+      );
+      const pluginSettings = {
+        ...this.pluginSettings,
+        ...(userPluginSettings || {}),
+      };
+      const plugins = this.loadPlugins(pluginSettings);
+      for (const plugin of plugins) {
+        await plugin.process(post);
+      }
+    }
+
+    await post.save();
+
     return post;
   }
 

--- a/src/platforms/Instagram/Instagram.ts
+++ b/src/platforms/Instagram/Instagram.ts
@@ -1,8 +1,6 @@
 import { basename } from "path";
 import { FileGroup, FieldMapping, OAuthRequest } from "../../types/index.ts";
 
-import Source from "../../models/Source.ts";
-
 import InstagramApi from "./InstagramApi.ts";
 import InstagramAuth from "./InstagramAuth.ts";
 import PlatformMapper from "../../mappers/PlatformMapper.ts";
@@ -101,10 +99,8 @@ export default class Instagram extends Platform {
   }
 
   /** @inheritdoc */
-  async preparePost(source: Source): Promise<Post> {
-    this.user.log.trace("Instagram.preparePost", source.id);
-    const post = await this.getPost(source);
-    await post.prepare();
+  async preparePost(post: Post) {
+    this.user.log.trace("Instagram.preparePost", post.id);
     // instagram: require media
     if (
       post.getFiles(FileGroup.IMAGE).length +
@@ -126,10 +122,6 @@ export default class Instagram extends Platform {
         await plugin.process(post);
       }
     }
-
-    await post.save();
-
-    return post;
   }
 
   /** @inheritdoc */

--- a/src/platforms/Instagram/Instagram.ts
+++ b/src/platforms/Instagram/Instagram.ts
@@ -20,6 +20,7 @@ export default class Instagram extends Platform {
   assetsFolder = "_instagram";
   postFileName = "post.json";
   pluginSettings = {
+    name: "INSTAGRAM_PLUGIN_SETTINGS",
     limitfiles: {
       total_max: 10,
     },
@@ -110,14 +111,7 @@ export default class Instagram extends Platform {
       post.valid = false;
     }
     if (post.valid) {
-      const userPluginSettings = JSON.parse(
-        this.user.data.get("settings", "INSTAGRAM_PLUGIN_SETTINGS", "{}"),
-      );
-      const pluginSettings = {
-        ...this.pluginSettings,
-        ...(userPluginSettings || {}),
-      };
-      const plugins = this.loadPlugins(pluginSettings);
+      const plugins = this.loadPlugins();
       for (const plugin of plugins) {
         await plugin.process(post);
       }

--- a/src/platforms/Instagram/Instagram.ts
+++ b/src/platforms/Instagram/Instagram.ts
@@ -110,12 +110,6 @@ export default class Instagram extends Platform {
     ) {
       post.valid = false;
     }
-    if (post.valid) {
-      const plugins = this.loadPlugins();
-      for (const plugin of plugins) {
-        await plugin.process(post);
-      }
-    }
   }
 
   /** @inheritdoc */

--- a/src/platforms/LinkedIn/LinkedIn.ts
+++ b/src/platforms/LinkedIn/LinkedIn.ts
@@ -13,6 +13,7 @@ export default class LinkedIn extends Platform {
   assetsFolder = "_linkedin";
   postFileName = "post.json";
   pluginSettings = {
+    name: "LINKEDIN_PLUGIN_SETTINGS",
     limitfiles: {
       exclusive: ["video"],
       video_max: 1,
@@ -104,14 +105,7 @@ export default class LinkedIn extends Platform {
   async preparePost(post: Post) {
     this.user.log.trace("LinkedIn.preparePost", post.id);
 
-    const userPluginSettings = JSON.parse(
-      this.user.data.get("settings", "LINKEDIN_PLUGIN_SETTINGS", "{}"),
-    );
-    const pluginSettings = {
-      ...this.pluginSettings,
-      ...(userPluginSettings || {}),
-    };
-    const plugins = this.loadPlugins(pluginSettings);
+    const plugins = this.loadPlugins();
     for (const plugin of plugins) {
       await plugin.process(post);
     }

--- a/src/platforms/LinkedIn/LinkedIn.ts
+++ b/src/platforms/LinkedIn/LinkedIn.ts
@@ -104,11 +104,7 @@ export default class LinkedIn extends Platform {
   /** @inheritdoc */
   async preparePost(post: Post) {
     this.user.log.trace("LinkedIn.preparePost", post.id);
-
-    const plugins = this.loadPlugins();
-    for (const plugin of plugins) {
-      await plugin.process(post);
-    }
+    // all good
   }
 
   /** @inheritdoc */

--- a/src/platforms/LinkedIn/LinkedIn.ts
+++ b/src/platforms/LinkedIn/LinkedIn.ts
@@ -104,21 +104,21 @@ export default class LinkedIn extends Platform {
   /** @inheritdoc */
   async preparePost(source: Source): Promise<Post> {
     this.user.log.trace("LinkedIn.preparePost", source.id);
-    const post = await super.preparePost(source);
-    if (post) {
-      const userPluginSettings = JSON.parse(
-        this.user.data.get("settings", "LINKEDIN_PLUGIN_SETTINGS", "{}"),
-      );
-      const pluginSettings = {
-        ...this.pluginSettings,
-        ...(userPluginSettings || {}),
-      };
-      const plugins = this.loadPlugins(pluginSettings);
-      for (const plugin of plugins) {
-        await plugin.process(post);
-      }
-      await post.save();
+    const post = await this.getPost(source);
+
+    const userPluginSettings = JSON.parse(
+      this.user.data.get("settings", "LINKEDIN_PLUGIN_SETTINGS", "{}"),
+    );
+    const pluginSettings = {
+      ...this.pluginSettings,
+      ...(userPluginSettings || {}),
+    };
+    const plugins = this.loadPlugins(pluginSettings);
+    for (const plugin of plugins) {
+      await plugin.process(post);
     }
+    await post.save();
+
     return post;
   }
 

--- a/src/platforms/LinkedIn/LinkedIn.ts
+++ b/src/platforms/LinkedIn/LinkedIn.ts
@@ -1,5 +1,4 @@
 import { FileGroup, FieldMapping, OAuthRequest } from "../../types/index.ts";
-import Source from "../../models/Source.ts";
 import { handleApiError, handleEmptyResponse } from "../../utilities.ts";
 
 import LinkedInApi from "./LinkedInApi.ts";
@@ -102,9 +101,8 @@ export default class LinkedIn extends Platform {
   }
 
   /** @inheritdoc */
-  async preparePost(source: Source): Promise<Post> {
-    this.user.log.trace("LinkedIn.preparePost", source.id);
-    const post = await this.getPost(source);
+  async preparePost(post: Post) {
+    this.user.log.trace("LinkedIn.preparePost", post.id);
 
     const userPluginSettings = JSON.parse(
       this.user.data.get("settings", "LINKEDIN_PLUGIN_SETTINGS", "{}"),
@@ -117,9 +115,6 @@ export default class LinkedIn extends Platform {
     for (const plugin of plugins) {
       await plugin.process(post);
     }
-    await post.save();
-
-    return post;
   }
 
   /** @inheritdoc */

--- a/src/platforms/Reddit/Reddit.ts
+++ b/src/platforms/Reddit/Reddit.ts
@@ -166,10 +166,6 @@ export default class Reddit extends Platform {
         videoposter = dstposter;
       }
     }
-    const plugins = this.loadPlugins();
-    for (const plugin of plugins) {
-      await plugin.process(post);
-    }
     if (videoposter) {
       await post.addFile(videoposter);
     }

--- a/src/platforms/Reddit/Reddit.ts
+++ b/src/platforms/Reddit/Reddit.ts
@@ -17,6 +17,7 @@ export default class Reddit extends Platform {
   assetsFolder = "_reddit";
   postFileName = "post.json";
   pluginSettings = {
+    name: "REDDIT_PLUGIN_SETTINGS",
     limitfiles: {
       prefer: ["video"],
       total_max: 1,
@@ -165,14 +166,7 @@ export default class Reddit extends Platform {
         videoposter = dstposter;
       }
     }
-    const userPluginSettings = JSON.parse(
-      this.user.data.get("settings", "REDDIT_PLUGIN_SETTINGS", "{}"),
-    );
-    const pluginSettings = {
-      ...this.pluginSettings,
-      ...(userPluginSettings || {}),
-    };
-    const plugins = this.loadPlugins(pluginSettings);
+    const plugins = this.loadPlugins();
     for (const plugin of plugins) {
       await plugin.process(post);
     }

--- a/src/platforms/Reddit/Reddit.ts
+++ b/src/platforms/Reddit/Reddit.ts
@@ -1,8 +1,6 @@
 import { basename } from "path";
 import { FileGroup, FieldMapping, OAuthRequest } from "../../types/index.ts";
 
-import Source from "../../models/Source.ts";
-
 import Platform from "../../models/Platform.ts";
 import Post from "../../models/Post.ts";
 import RedditApi from "./RedditApi.ts";
@@ -122,10 +120,8 @@ export default class Reddit extends Platform {
   }
 
   /** @inheritdoc */
-  async preparePost(source: Source): Promise<Post> {
-    this.user.log.trace("Reddit.preparePost", source.id);
-    const post = await this.getPost(source);
-    await post.prepare();
+  async preparePost(post: Post) {
+    this.user.log.trace("Reddit.preparePost", post.id);
     // TODO: extract video thumbnail
     let videoposter = "";
     if (post.hasFiles(FileGroup.VIDEO)) {
@@ -183,9 +179,6 @@ export default class Reddit extends Platform {
     if (videoposter) {
       await post.addFile(videoposter);
     }
-    await post.save();
-
-    return post;
   }
 
   /** @inheritdoc */

--- a/src/platforms/Reddit/Reddit.ts
+++ b/src/platforms/Reddit/Reddit.ts
@@ -124,67 +124,67 @@ export default class Reddit extends Platform {
   /** @inheritdoc */
   async preparePost(source: Source): Promise<Post> {
     this.user.log.trace("Reddit.preparePost", source.id);
-    const post = await super.preparePost(source);
-    if (post) {
-      // TODO: extract video thumbnail
-      let videoposter = "";
-      if (post.hasFiles(FileGroup.VIDEO)) {
-        let srcposter = "";
-        const dstposter = this.assetsFolder + "/reddit-poster.png";
-        const posters = post
-          .getFiles(FileGroup.IMAGE)
-          .filter((file) => file.basename === "poster");
-        if (posters.length) {
-          srcposter = posters[0].name;
-        } else if (post.hasFiles(FileGroup.IMAGE)) {
-          // copy the first image to poster
-          srcposter = post.getFiles(FileGroup.IMAGE)[0].name;
-        } else {
-          // create a poster using ffmpeg
-          try {
-            throw this.user.log.error(
-              "video poster.jpg missing - thumbnails not implemented",
-            );
-            // https://creatomate.com/blog/how-to-use-ffmpeg-in-nodejs
-            // const video = post.getFiles('video')[0];
-            // this.user.log.trace("Reddit.preparePost", "creating thumbnail", video.name, dstposter);
-            // this.generateThumbnail(post.getFilePath(video.name),post.getFilePath(dstposter));
-          } catch {
-            post.valid = false;
-          }
-        }
-        if (srcposter) {
-          // copy that file to its dest
-          this.user.log.trace(
-            "Reddit.preparePost",
-            "copying poster",
-            srcposter,
-            dstposter,
+    const post = await this.getPost(source);
+    await post.prepare();
+    // TODO: extract video thumbnail
+    let videoposter = "";
+    if (post.hasFiles(FileGroup.VIDEO)) {
+      let srcposter = "";
+      const dstposter = this.assetsFolder + "/reddit-poster.png";
+      const posters = post
+        .getFiles(FileGroup.IMAGE)
+        .filter((file) => file.basename === "poster");
+      if (posters.length) {
+        srcposter = posters[0].name;
+      } else if (post.hasFiles(FileGroup.IMAGE)) {
+        // copy the first image to poster
+        srcposter = post.getFiles(FileGroup.IMAGE)[0].name;
+      } else {
+        // create a poster using ffmpeg
+        try {
+          throw this.user.log.error(
+            "video poster.jpg missing - thumbnails not implemented",
           );
-          await this.user.files.copy(
-            post.getFilePath(srcposter),
-            post.getFilePath(dstposter),
-          );
-          post.removeFiles(FileGroup.IMAGE);
-          videoposter = dstposter;
+          // https://creatomate.com/blog/how-to-use-ffmpeg-in-nodejs
+          // const video = post.getFiles('video')[0];
+          // this.user.log.trace("Reddit.preparePost", "creating thumbnail", video.name, dstposter);
+          // this.generateThumbnail(post.getFilePath(video.name),post.getFilePath(dstposter));
+        } catch {
+          post.valid = false;
         }
       }
-      const userPluginSettings = JSON.parse(
-        this.user.data.get("settings", "REDDIT_PLUGIN_SETTINGS", "{}"),
-      );
-      const pluginSettings = {
-        ...this.pluginSettings,
-        ...(userPluginSettings || {}),
-      };
-      const plugins = this.loadPlugins(pluginSettings);
-      for (const plugin of plugins) {
-        await plugin.process(post);
+      if (srcposter) {
+        // copy that file to its dest
+        this.user.log.trace(
+          "Reddit.preparePost",
+          "copying poster",
+          srcposter,
+          dstposter,
+        );
+        await this.user.files.copy(
+          post.getFilePath(srcposter),
+          post.getFilePath(dstposter),
+        );
+        post.removeFiles(FileGroup.IMAGE);
+        videoposter = dstposter;
       }
-      if (videoposter) {
-        await post.addFile(videoposter);
-      }
-      await post.save();
     }
+    const userPluginSettings = JSON.parse(
+      this.user.data.get("settings", "REDDIT_PLUGIN_SETTINGS", "{}"),
+    );
+    const pluginSettings = {
+      ...this.pluginSettings,
+      ...(userPluginSettings || {}),
+    };
+    const plugins = this.loadPlugins(pluginSettings);
+    for (const plugin of plugins) {
+      await plugin.process(post);
+    }
+    if (videoposter) {
+      await post.addFile(videoposter);
+    }
+    await post.save();
+
     return post;
   }
 

--- a/src/platforms/Twitter/Twitter.ts
+++ b/src/platforms/Twitter/Twitter.ts
@@ -1,5 +1,4 @@
 import { FileGroup, FieldMapping } from "../../types/index.ts";
-import Source from "../../models/Source.ts";
 
 import Platform from "../../models/Platform.ts";
 import Post from "../../models/Post.ts";
@@ -111,10 +110,8 @@ export default class Twitter extends Platform {
   }
 
   /** @inheritdoc */
-  async preparePost(source: Source): Promise<Post> {
-    this.user.log.trace("Twitter.preparePost", source.id);
-    const post = await this.getPost(source);
-    await post.prepare();
+  async preparePost(post: Post) {
+    this.user.log.trace("Twitter.preparePost", post.id);
     const userPluginSettings = JSON.parse(
       this.user.data.get("settings", "TWITTER_PLUGIN_SETTINGS", "{}"),
     );
@@ -166,9 +163,6 @@ export default class Twitter extends Platform {
       this.user.log.warn("Twitter post has no body");
       post.valid = false;
     }
-    await post.save();
-
-    return post;
   }
 
   /** @inheritdoc */

--- a/src/platforms/Twitter/Twitter.ts
+++ b/src/platforms/Twitter/Twitter.ts
@@ -113,63 +113,61 @@ export default class Twitter extends Platform {
   /** @inheritdoc */
   async preparePost(source: Source): Promise<Post> {
     this.user.log.trace("Twitter.preparePost", source.id);
-    const post = await super.preparePost(source);
-    if (post) {
-      const userPluginSettings = JSON.parse(
-        this.user.data.get("settings", "TWITTER_PLUGIN_SETTINGS", "{}"),
-      );
-      const pluginSettings = {
-        ...this.pluginSettings,
-        ...(userPluginSettings || {}),
-      };
-      const plugins = this.loadPlugins(pluginSettings);
-      for (const plugin of plugins) {
-        await plugin.process(post);
-      }
-
-      // remove files whose mime are not supported,
-      // this could be a plugin
-      for (const file of post.getFiles()) {
-        if (
-          !Object.values(EUploadMimeType).includes(
-            file.mimetype as EUploadMimeType,
-          )
-        ) {
-          this.user.log.trace(
-            "Removing unsupported file type: " + file.mimetype,
-          );
-          post.removeFile(file.name);
-        }
-      }
-
-      // limit the post body to 140 characters
-      // this could be a plugin
-      const charLimit = 140;
-      if (post.body && post.body.length >= charLimit) {
-        const splitBody = post.body.match(/[^.\n]+[.\n]*|[.\n]+/g);
-        if (splitBody) {
-          let newBody = "";
-          let nextLine = splitBody.shift();
-          while (nextLine && newBody.length + nextLine.length < charLimit) {
-            newBody += nextLine;
-            nextLine = splitBody.shift();
-          }
-          if (newBody !== "") {
-            post.body = newBody;
-          }
-        }
-        if (post.body.length >= charLimit) {
-          post.body = post.body.substring(0, charLimit - 4) + "...";
-        }
-      }
-
-      // twitter requires a real body or images
-      if (!post.body && !post.hasFiles(FileGroup.IMAGE)) {
-        this.user.log.warn("Twitter post has no body");
-        post.valid = false;
-      }
-      await post.save();
+    const post = await this.getPost(source);
+    await post.prepare();
+    const userPluginSettings = JSON.parse(
+      this.user.data.get("settings", "TWITTER_PLUGIN_SETTINGS", "{}"),
+    );
+    const pluginSettings = {
+      ...this.pluginSettings,
+      ...(userPluginSettings || {}),
+    };
+    const plugins = this.loadPlugins(pluginSettings);
+    for (const plugin of plugins) {
+      await plugin.process(post);
     }
+
+    // remove files whose mime are not supported,
+    // this could be a plugin
+    for (const file of post.getFiles()) {
+      if (
+        !Object.values(EUploadMimeType).includes(
+          file.mimetype as EUploadMimeType,
+        )
+      ) {
+        this.user.log.trace("Removing unsupported file type: " + file.mimetype);
+        post.removeFile(file.name);
+      }
+    }
+
+    // limit the post body to 140 characters
+    // this could be a plugin
+    const charLimit = 140;
+    if (post.body && post.body.length >= charLimit) {
+      const splitBody = post.body.match(/[^.\n]+[.\n]*|[.\n]+/g);
+      if (splitBody) {
+        let newBody = "";
+        let nextLine = splitBody.shift();
+        while (nextLine && newBody.length + nextLine.length < charLimit) {
+          newBody += nextLine;
+          nextLine = splitBody.shift();
+        }
+        if (newBody !== "") {
+          post.body = newBody;
+        }
+      }
+      if (post.body.length >= charLimit) {
+        post.body = post.body.substring(0, charLimit - 4) + "...";
+      }
+    }
+
+    // twitter requires a real body or images
+    if (!post.body && !post.hasFiles(FileGroup.IMAGE)) {
+      this.user.log.warn("Twitter post has no body");
+      post.valid = false;
+    }
+    await post.save();
+
     return post;
   }
 

--- a/src/platforms/Twitter/Twitter.ts
+++ b/src/platforms/Twitter/Twitter.ts
@@ -113,10 +113,6 @@ export default class Twitter extends Platform {
   /** @inheritdoc */
   async preparePost(post: Post) {
     this.user.log.trace("Twitter.preparePost", post.id);
-    const plugins = this.loadPlugins();
-    for (const plugin of plugins) {
-      await plugin.process(post);
-    }
 
     // remove files whose mime are not supported,
     // this could be a plugin

--- a/src/platforms/Twitter/Twitter.ts
+++ b/src/platforms/Twitter/Twitter.ts
@@ -26,6 +26,7 @@ export default class Twitter extends Platform {
   assetsFolder = "_twitter";
   postFileName = "post.json";
   pluginSettings = {
+    name: "TWITTER_PLUGIN_SETTINGS",
     limitfiles: {
       video_max: 0,
       image_max: 4,
@@ -112,14 +113,7 @@ export default class Twitter extends Platform {
   /** @inheritdoc */
   async preparePost(post: Post) {
     this.user.log.trace("Twitter.preparePost", post.id);
-    const userPluginSettings = JSON.parse(
-      this.user.data.get("settings", "TWITTER_PLUGIN_SETTINGS", "{}"),
-    );
-    const pluginSettings = {
-      ...this.pluginSettings,
-      ...(userPluginSettings || {}),
-    };
-    const plugins = this.loadPlugins(pluginSettings);
+    const plugins = this.loadPlugins();
     for (const plugin of plugins) {
       await plugin.process(post);
     }

--- a/src/platforms/YouTube/YouTube.ts
+++ b/src/platforms/YouTube/YouTube.ts
@@ -11,6 +11,7 @@ export default class YouTube extends Platform {
   assetsFolder = "_youtube";
   postFileName = "post.json";
   pluginSettings = {
+    name: "YOUTUBE_PLUGIN_SETTINGS",
     limitfiles: {
       exclusive: ["video"],
       video_min: 1,
@@ -103,14 +104,7 @@ export default class YouTube extends Platform {
   /** @inheritdoc */
   async preparePost(post: Post) {
     this.user.log.trace("YouTube.preparePost", post.id);
-    const userPluginSettings = JSON.parse(
-      this.user.data.get("settings", "YOUTUBE_PLUGIN_SETTINGS", "{}"),
-    );
-    const pluginSettings = {
-      ...this.pluginSettings,
-      ...(userPluginSettings || {}),
-    };
-    const plugins = this.loadPlugins(pluginSettings);
+    const plugins = this.loadPlugins();
     for (const plugin of plugins) {
       await plugin.process(post);
     }

--- a/src/platforms/YouTube/YouTube.ts
+++ b/src/platforms/YouTube/YouTube.ts
@@ -104,21 +104,21 @@ export default class YouTube extends Platform {
   /** @inheritdoc */
   async preparePost(source: Source): Promise<Post> {
     this.user.log.trace("YouTube.preparePost", source.id);
-    const post = await super.preparePost(source);
-    if (post) {
-      const userPluginSettings = JSON.parse(
-        this.user.data.get("settings", "YOUTUBE_PLUGIN_SETTINGS", "{}"),
-      );
-      const pluginSettings = {
-        ...this.pluginSettings,
-        ...(userPluginSettings || {}),
-      };
-      const plugins = this.loadPlugins(pluginSettings);
-      for (const plugin of plugins) {
-        await plugin.process(post);
-      }
-      await post.save();
+    const post = await this.getPost(source);
+    await post.prepare();
+    const userPluginSettings = JSON.parse(
+      this.user.data.get("settings", "YOUTUBE_PLUGIN_SETTINGS", "{}"),
+    );
+    const pluginSettings = {
+      ...this.pluginSettings,
+      ...(userPluginSettings || {}),
+    };
+    const plugins = this.loadPlugins(pluginSettings);
+    for (const plugin of plugins) {
+      await plugin.process(post);
     }
+    await post.save();
+
     return post;
   }
 

--- a/src/platforms/YouTube/YouTube.ts
+++ b/src/platforms/YouTube/YouTube.ts
@@ -1,5 +1,4 @@
 import { FileGroup, FieldMapping, OAuthRequest } from "../../types/index.ts";
-import Source from "../../models/Source.ts";
 
 import Platform from "../../models/Platform.ts";
 import Post from "../../models/Post.ts";
@@ -102,10 +101,8 @@ export default class YouTube extends Platform {
   }
 
   /** @inheritdoc */
-  async preparePost(source: Source): Promise<Post> {
-    this.user.log.trace("YouTube.preparePost", source.id);
-    const post = await this.getPost(source);
-    await post.prepare();
+  async preparePost(post: Post) {
+    this.user.log.trace("YouTube.preparePost", post.id);
     const userPluginSettings = JSON.parse(
       this.user.data.get("settings", "YOUTUBE_PLUGIN_SETTINGS", "{}"),
     );
@@ -117,9 +114,6 @@ export default class YouTube extends Platform {
     for (const plugin of plugins) {
       await plugin.process(post);
     }
-    await post.save();
-
-    return post;
   }
 
   /** @inheritdoc */

--- a/src/platforms/YouTube/YouTube.ts
+++ b/src/platforms/YouTube/YouTube.ts
@@ -104,10 +104,7 @@ export default class YouTube extends Platform {
   /** @inheritdoc */
   async preparePost(post: Post) {
     this.user.log.trace("YouTube.preparePost", post.id);
-    const plugins = this.loadPlugins();
-    for (const plugin of plugins) {
-      await plugin.process(post);
-    }
+    // all good
   }
 
   /** @inheritdoc */

--- a/src/services/Fairpost.ts
+++ b/src/services/Fairpost.ts
@@ -670,7 +670,8 @@ class Fairpost {
           const platform = user.getPlatform(args.platform);
           const feed = user.getFeed();
           const source = await feed.getSource(args.source);
-          const post = await platform.preparePost(source);
+          const post = await platform.getPost(source);
+          await post.prepare();
           output = await post.mapper.getDto(operator);
           break;
         }
@@ -701,7 +702,8 @@ class Fairpost {
                 output[platform.id] = [];
               }
               try {
-                const post = await platform.preparePost(source);
+                const post = await platform.getPost(source);
+                await post.prepare();
                 (output[platform.id] as CombinedResult[]).push({
                   success: true,
                   result: await post.mapper.getDto(operator),


### PR DESCRIPTION
In general, move the responsibility of post actions to the post model, so the Platform models become simpler. 
The post is not a simple child of a platform, it is a join of a platform and a source. Also, models should not have static methods. 

- Most importantly, create a `PostFactory.resolve(platform,source)` instead of `static Post.getPost` and Platform.getPost or Source.getPost mess. A post does not belong to a platform or a source, but to both
- add a user property to post, because it is neither this.platform.user nor this.source.feed.user
- removing all other static methods from models into their container; because a model is a model
- Move Platform.super.preparePost to post.prepare(); because it didnt add much value and was confusing
- Move plugin.process to Post.prepare - now Platform.preparePost can be empty if all is handled by plugins